### PR TITLE
Update file paths to use here()

### DIFF
--- a/R/nhl_ev_retrieval/collectors/goalies.R
+++ b/R/nhl_ev_retrieval/collectors/goalies.R
@@ -8,11 +8,12 @@ suppressPackageStartupMessages({
   library(rvest)
   library(stringr)
   library(anytime)
+  library(here)
 })
 
-# Source utilities
-source(file.path(dirname(dirname(sys.frame(1)$ofile)), "utils", "common.R"))
-source(file.path(dirname(dirname(sys.frame(1)$ofile)), "utils", "selenium_manager.R"))
+# Source utilities using here()
+source(here("R", "nhl_ev_retrieval", "utils", "common.R"))
+source(here("R", "nhl_ev_retrieval", "utils", "selenium_manager.R"))
 
 # EXTRACTION FUNCTIONS (USING PROVEN LOGIC FROM PASTE.TXT) ----------------
 

--- a/R/nhl_ev_retrieval/collectors/odds.R
+++ b/R/nhl_ev_retrieval/collectors/odds.R
@@ -6,11 +6,12 @@
 suppressPackageStartupMessages({
   library(data.table)
   library(lubridate)
+  library(here)
 })
 
-# Source utilities
-source(file.path(dirname(dirname(sys.frame(1)$ofile)), "utils", "common.R"))
-source(file.path(dirname(dirname(sys.frame(1)$ofile)), "utils", "api_client.R"))
+# Source utilities using here()
+source(here("R", "nhl_ev_retrieval", "utils", "common.R"))
+source(here("R", "nhl_ev_retrieval", "utils", "api_client.R"))
 
 # PARSING FUNCTIONS --------------------------------------------------------
 

--- a/R/nhl_ev_retrieval/collectors/probabilities.R
+++ b/R/nhl_ev_retrieval/collectors/probabilities.R
@@ -7,11 +7,12 @@ suppressPackageStartupMessages({
   library(data.table)
   library(rvest)
   library(stringr)
+  library(here)
 })
 
-# Source utilities
-source(file.path(dirname(dirname(sys.frame(1)$ofile)), "utils", "common.R"))
-source(file.path(dirname(dirname(sys.frame(1)$ofile)), "utils", "selenium_manager.R"))
+# Source utilities using here()
+source(here("R", "nhl_ev_retrieval", "utils", "common.R"))
+source(here("R", "nhl_ev_retrieval", "utils", "selenium_manager.R"))
 
 # EXTRACTION FUNCTIONS -----------------------------------------------------
 

--- a/R/nhl_ev_retrieval/collectors/schedule.R
+++ b/R/nhl_ev_retrieval/collectors/schedule.R
@@ -6,30 +6,12 @@
 suppressPackageStartupMessages({
   library(data.table)
   library(lubridate)
+  library(here)
 })
 
-# Source utilities - use more robust path detection
-if (!exists("nhl_config")) {
-  # Try relative path first
-  if (file.exists("utils/common.R")) {
-    source("utils/common.R")
-  } else if (file.exists("../utils/common.R")) {
-    source("../utils/common.R")
-  } else {
-    stop("Cannot find common.R - please ensure working directory is correct")
-  }
-}
-
-if (!exists("api_get")) {
-  # Try relative path first
-  if (file.exists("utils/api_client.R")) {
-    source("utils/api_client.R")
-  } else if (file.exists("../utils/api_client.R")) {
-    source("../utils/api_client.R")
-  } else {
-    stop("Cannot find api_client.R - please ensure working directory is correct")
-  }
-}
+# Source utilities using here()
+source(here("R", "nhl_ev_retrieval", "utils", "common.R"))
+source(here("R", "nhl_ev_retrieval", "utils", "api_client.R"))
 
 # HELPER FUNCTIONS ---------------------------------------------------------
 

--- a/R/nhl_ev_retrieval/master.R
+++ b/R/nhl_ev_retrieval/master.R
@@ -5,23 +5,16 @@
 
 suppressPackageStartupMessages({
   library(data.table)
+  library(here)
 })
-
-# Get script directory
-if (interactive()) {
-  script_dir <- getwd()
-} else {
-  script_dir <- dirname(sys.frame(1)$ofile)
-}
-
-# Source all modules
-source(file.path(script_dir, "utils", "common.R"))
-source(file.path(script_dir, "utils", "api_client.R"))
-source(file.path(script_dir, "utils", "selenium_manager.R"))
-source(file.path(script_dir, "collectors", "schedule.R"))
-source(file.path(script_dir, "collectors", "probabilities.R"))
-source(file.path(script_dir, "collectors", "odds.R"))
-source(file.path(script_dir, "collectors", "goalies.R"))
+# Source all modules using here()
+source(here("R", "nhl_ev_retrieval", "utils", "common.R"))
+source(here("R", "nhl_ev_retrieval", "utils", "api_client.R"))
+source(here("R", "nhl_ev_retrieval", "utils", "selenium_manager.R"))
+source(here("R", "nhl_ev_retrieval", "collectors", "schedule.R"))
+source(here("R", "nhl_ev_retrieval", "collectors", "probabilities.R"))
+source(here("R", "nhl_ev_retrieval", "collectors", "odds.R"))
+source(here("R", "nhl_ev_retrieval", "collectors", "goalies.R"))
 
 # MAIN FUNCTIONS -----------------------------------------------------------
 

--- a/R/nhl_ev_retrieval/update_bigquery.R
+++ b/R/nhl_ev_retrieval/update_bigquery.R
@@ -12,17 +12,11 @@ suppressPackageStartupMessages({
   library(gargle)
   library(lubridate)
   library(dplyr)
+  library(here)
 })
 
-# Get script directory
-if (interactive()) {
-  script_dir <- getwd()
-} else {
-  script_dir <- dirname(sys.frame(1)$ofile)
-}
-
-# Source utilities
-source(file.path(script_dir, "utils", "common.R"))
+# Source utilities using here()
+source(here("R", "nhl_ev_retrieval", "utils", "common.R"))
 
 # CONFIGURATION ------------------------------------------------------------
 

--- a/R/nhl_ev_retrieval/utils/selenium_manager.R
+++ b/R/nhl_ev_retrieval/utils/selenium_manager.R
@@ -7,10 +7,11 @@ suppressPackageStartupMessages({
   library(R6)
   library(RSelenium)
   library(data.table)
+  library(here)
 })
 
-# Source common utilities
-source(file.path(dirname(dirname(sys.frame(1)$ofile)), "utils", "common.R"))
+# Source common utilities using here()
+source(here("R", "nhl_ev_retrieval", "utils", "common.R"))
 
 # DOCKER MANAGEMENT FUNCTIONS ----------------------------------------------
 


### PR DESCRIPTION
## Summary
- load `here` in all NHL retrieval scripts
- use `here()` for sourcing instead of manual path calculation

## Testing
- `git log -1 --stat`
- *Codex couldn't run certain commands due to environment limitations. Consider configuring a setup script or internet access in your Codex environment to install dependencies.*

------
https://chatgpt.com/codex/tasks/task_b_684f68a271888331b682e341bb6244da