### PR TITLE
Fix goalie parser test path

### DIFF
--- a/tests/testthat/test-goalie-parser.R
+++ b/tests/testthat/test-goalie-parser.R
@@ -5,7 +5,7 @@ library(testthat)
 
 skip_if_not_installed('anytime')
 source(here::here('R','nhl_ev_retrieval','collectors','goalies.R'), local = TRUE)
-html_text <- readLines("testdata/goalies_sample.html")
+html_text <- readLines(here::here("tests","testthat","testdata","goalies_sample.html"))
 
 test_that('extract_goalie_data parses goalies', {
   dt <- extract_goalie_data(paste(html_text, collapse='\n'))


### PR DESCRIPTION
## Summary
- make `test-goalie-parser.R` use a path relative to the project root

## Testing
- `R -q -e 'testthat::test_dir("tests/testthat")'` *(fails: there is no package called 'testthat')*

------
https://chatgpt.com/codex/tasks/task_b_685099d1ddd48331a8a8f55d660d2f32