### PR TITLE
Fix default date logic for score retrieval

### DIFF
--- a/R/nhl_ev_retrieval/master.R
+++ b/R/nhl_ev_retrieval/master.R
@@ -305,8 +305,20 @@ retrieve_nhl_scores <- function(dates = NULL, save_file = TRUE) {
   init_logging("scores")
   check_delay_arg()
   ensure_directories()
-  
-  # Parse dates
+
+  # Custom default dates: yesterday only
+  if (is.null(dates)) {
+    args <- commandArgs(trailingOnly = TRUE)
+    args <- setdiff(args, c("scores", "delay"))
+
+    if (length(args) > 0) {
+      dates <- args
+    } else {
+      dates <- Sys.Date() - 1
+      log_message("No dates specified, using yesterday's date", "INFO")
+    }
+  }
+
   dates <- parse_date_args(dates)
   
   log_message(sprintf("=== NHL Scores Retrieval for %d dates ===", length(dates)), "INFO")


### PR DESCRIPTION
## Summary
- fetch previous day's scores by default
- skip `scores` and `delay` args when parsing command line parameters

## Testing
- `R --version` *(fails: command not found)*
- `Rscript -e '1+1'` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_b_6852e69fc8ec83319a17c4880eb0f83e