### PR TITLE
Fix key setup in update_completed_games

### DIFF
--- a/R/nhl_ev_retrieval/update_bigquery.R
+++ b/R/nhl_ev_retrieval/update_bigquery.R
@@ -487,8 +487,8 @@ update_completed_games <- function(completed_games) {
       
       if (length(existing_key_cols) == length(new_key_cols) && 
           length(existing_key_cols) > 0) {
-        setkey(existing, existing_key_cols)
-        setkey(completed_games, new_key_cols)
+        setkeyv(existing, existing_key_cols)
+        setkeyv(completed_games, new_key_cols)
         new_only <- completed_games[!existing]
       } else {
         # If key columns don't match, append all


### PR DESCRIPTION
## Summary
- use `setkeyv()` to set keys by vector names in `update_completed_games`

## Testing
- `R -q -e "library(testthat); test_dir('tests/testthat')"` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_b_685325fbc0d483318cafa9e92c0be666