### PR TITLE
Remove stray debug output

### DIFF
--- a/R/01_ESPN_update_ev/01_ESPN_schedule_retrieval.R
+++ b/R/01_ESPN_update_ev/01_ESPN_schedule_retrieval.R
@@ -212,7 +212,6 @@ parse_espn_games <- function(events_data, date, sport_info) {
   
   # Process each event
   for (i in seq_along(events_data$items[["$ref"]])) {
-    print(i)
     if(sport_info$name == "MLB"){
       event_url <- events_data[["items"]][["$ref"]][[i]][1]
     } else {


### PR DESCRIPTION
## Summary
- remove leftover print statement from ESPN schedule retrieval script

## Testing
- `R -q -e "source('tests/testthat.R')"` *(fails: there is no package called `testthat`)*

------
https://chatgpt.com/codex/tasks/task_b_6855acc1748083318efe3a326eecaba1