### PR TITLE
Improve odds and schedule join

### DIFF
--- a/R/01_ESPN_update_ev/00_master_ESPN_update_ev.R
+++ b/R/01_ESPN_update_ev/00_master_ESPN_update_ev.R
@@ -469,18 +469,35 @@ retrieve_espn_expected_values <- function(manual_dates = NULL, sport = "NBA") {
       ) %>%
       filter(!is.na(win_probability))  # Only keep rows with win probabilities
   } else {
-    # Merge win probabilities with odds
-    final_data <- h2h_odds %>%
-      left_join(
-        games_key,
-        by = c("home_team_full", 'away_team_full', "game_date")
-      ) %>%
+    # Perform a rolling join similar to the NHL master script
+    # Restrict matches to start times within two hours of the scheduled game
+    h2h_odds_dt <- as.data.table(h2h_odds)
+    games_key_dt <- as.data.table(games_key)
+
+    setkey(h2h_odds_dt,  home_team_full, away_team_full, game_date, game_datetime)
+    setkey(games_key_dt, home_team_full, away_team_full, game_date, game_datetime)
+
+    joined <- data.frame(
+      games_key_dt[h2h_odds_dt,
+                   on = .(
+                     home_team_full,
+                     away_team_full,
+                     game_date,
+                     game_datetime
+                   ),
+                   roll = "nearest"]
+    )
+
+    joined <- joined %>%
+      filter(abs(game_datetime - i.game_datetime) <= 2 * 3600)
+
+    final_data <- joined %>%
       left_join(
         win_prob_data,
         by = c("name" = "team", "game_date" = "date", "game_id"),
         suffix = c("_odds", "_wp")
       ) %>%
-      filter(!is.na(win_probability))  # Only keep rows with win probabilities 
+      filter(!is.na(win_probability))  # Only keep rows with win probabilities
   }
   
   # CALCULATE EXPECTED VALUES --------------------------------------------------


### PR DESCRIPTION
## Summary
- join odds to game metadata for NBA/NFL using a data.table rolling join and a 2 hour tolerance

## Testing
- `Rscript -e 'sessionInfo()'` *(fails: command not found)*
- `R -q -e 'library(testthat); test_dir("tests")'` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_b_6855ae1d81188331804051dff36b5a0d