### PR TITLE
Refactor ESPN EV retrieval

### DIFF
--- a/R/espn_ev_retrieval/collectors/odds.R
+++ b/R/espn_ev_retrieval/collectors/odds.R
@@ -1,0 +1,328 @@
+# SPORTS BETTING ODDS COLLECTOR -------------------------------------------
+# Purpose: Collect betting odds with date range API
+# Author: Professional implementation with data.table
+# Last Updated: 2025-12-19
+
+suppressPackageStartupMessages({
+  library(data.table)
+  library(lubridate)
+  library(here)
+})
+
+# Source utilities using here()
+source(here("R", "espn_ev_retrieval", "utils", "common.R"))
+source(here("R", "espn_ev_retrieval", "utils", "api_client.R"))
+
+# Sport mapping for Odds API
+SPORT_MAPPINGS <- list(
+  NBA = "basketball_nba",
+  NFL = "americanfootball_nfl",
+  MLB = "baseball_mlb",
+  NHL = "icehockey_nhl"
+)
+
+# PARSING FUNCTIONS --------------------------------------------------------
+
+#' Parse nested JSON odds data using pure data.table approach
+#' @param raw_data Raw API response (data.frame with nested list-columns)
+#' @return data.table with flattened odds data
+parse_odds_efficient <- function(raw_data) {
+  if (is.null(raw_data) || nrow(raw_data) == 0) {
+    log_message("No odds data to parse", "DEBUG")
+    return(data.table())
+  }
+  
+  tryCatch({
+    # Convert to data.table and add game_id for tracking
+    games_dt <- as.data.table(raw_data)
+    games_dt[, game_id := .I]
+    
+    # Step 1: Unnest bookmakers
+    # Extract game-level info without bookmakers column
+    game_info <- games_dt[, .(game_id, id, sport_key, sport_title, commence_time, home_team, away_team)]
+    
+    # Extract and unnest bookmakers
+    bookmakers_list <- list()
+    for (i in seq_len(nrow(games_dt))) {
+      game_bookmakers <- games_dt$bookmakers[[i]]
+      if (!is.null(game_bookmakers) && nrow(game_bookmakers) > 0) {
+        # Add game_id and bookmaker_id to track relationships
+        game_bookmakers_dt <- as.data.table(game_bookmakers)
+        game_bookmakers_dt[, `:=`(game_id = i, bookmaker_id = .I)]
+        bookmakers_list[[i]] <- game_bookmakers_dt
+      }
+    }
+    
+    if (length(bookmakers_list) == 0) {
+      log_message("No bookmakers found in odds data", "WARN")
+      return(data.table())
+    }
+    
+    # Combine all bookmakers
+    bookmakers_dt <- rbindlist(bookmakers_list, fill = TRUE)
+    
+    # Step 2: Unnest markets
+    markets_list <- list()
+    for (i in seq_len(nrow(bookmakers_dt))) {
+      bookmaker_markets <- bookmakers_dt$markets[[i]]
+      if (!is.null(bookmaker_markets) && nrow(bookmaker_markets) > 0) {
+        # bookmaker_markets is already a data.frame of markets
+        market_dt <- as.data.table(bookmaker_markets)
+        market_dt[, `:=`(
+          game_id = bookmakers_dt$game_id[i],
+          bookmaker_id = bookmakers_dt$bookmaker_id[i],
+          market_id = .I  # Use row number as market_id
+        )]
+        markets_list[[length(markets_list) + 1]] <- market_dt
+      }
+    }
+    
+    if (length(markets_list) == 0) {
+      log_message("No markets found in odds data", "WARN")
+      return(data.table())
+    }
+    
+    # Combine all markets
+    markets_dt <- rbindlist(markets_list, fill = TRUE)
+    
+    # Step 3: Unnest outcomes
+    outcomes_list <- list()
+    for (i in seq_len(nrow(markets_dt))) {
+      market_outcomes <- markets_dt$outcomes[[i]]
+      if (!is.null(market_outcomes) && nrow(market_outcomes) > 0) {
+        outcomes_dt <- as.data.table(market_outcomes)
+        outcomes_dt[, `:=`(
+          game_id = markets_dt$game_id[i],
+          bookmaker_id = markets_dt$bookmaker_id[i],
+          market_id = markets_dt$market_id[i]
+        )]
+        outcomes_list[[length(outcomes_list) + 1]] <- outcomes_dt
+      }
+    }
+    
+    if (length(outcomes_list) == 0) {
+      log_message("No outcomes found in odds data", "WARN")
+      return(data.table())
+    }
+    
+    # Combine all outcomes
+    outcomes_dt <- rbindlist(outcomes_list, fill = TRUE)
+    
+    # Step 4: Join everything back together
+    # Join outcomes with markets (excluding outcomes column)
+    markets_clean <- markets_dt[, !c("outcomes")]
+    setnames(markets_clean, "key", "market", skip_absent = TRUE)
+    setnames(markets_clean, "last_update", "market_last_update", skip_absent = TRUE)
+    
+    odds_dt <- merge(outcomes_dt, markets_clean, 
+                     by = c("game_id", "bookmaker_id", "market_id"), 
+                     all.x = TRUE)
+    
+    # Join with bookmakers (excluding markets column)
+    bookmakers_clean <- bookmakers_dt[, !c("markets")]
+    setnames(bookmakers_clean, "key", "book", skip_absent = TRUE)
+    setnames(bookmakers_clean, "title", "book_title", skip_absent = TRUE)
+    # setnames(bookmakers_clean, "last_update", "book_last_update", skip_absent = TRUE)
+    
+    odds_dt <- merge(odds_dt, bookmakers_clean,
+                     by = c("game_id", "bookmaker_id"),
+                     all.x = TRUE)
+    
+    # Join with game info
+    odds_dt <- merge(odds_dt, game_info,
+                     by = "game_id",
+                     all.x = TRUE)
+    
+    # Step 5: Clean up and format
+    # Remove ID columns used for tracking
+    odds_dt[, `:=`(game_id = NULL, bookmaker_id = NULL, market_id = NULL)]
+    
+    # Parse timestamps
+    if ("commence_time" %in% names(odds_dt)) {
+      odds_dt[, `:=`(
+        game_time = format(as.POSIXct(commence_time, format = "%Y-%m-%dT%H:%M:%SZ", tz = "UTC"),
+                                      format = "%H:%M", tz = "America/New_York"),
+        game_date = as.Date(format(as.POSIXct(commence_time, format = "%Y-%m-%dT%H:%M:%SZ", tz = "UTC"),
+                                   format = "%Y-%m-%dT%H:%M:%SZ", tz = "America/New_York"))
+      )]
+    }
+    
+    # if ("book_last_update" %in% names(odds_dt)) {
+    #   odds_dt[, book_last_update := format(as.POSIXct(book_last_update, format = "%Y-%m-%dT%H:%M:%SZ", tz = "UTC"), tz = "America/New_York")]
+    # }
+    
+    if ("market_last_update" %in% names(odds_dt)) {
+      odds_dt[, market_last_update := format(as.POSIXct(market_last_update, format = "%Y-%m-%dT%H:%M:%SZ", tz = "UTC"), tz = "America/New_York")]
+    }
+    
+    # Ensure numeric columns are properly typed
+    if ("price" %in% names(odds_dt)) {
+      odds_dt[, price := as.numeric(price)]
+    }
+    
+    if ("point" %in% names(odds_dt)) {
+      odds_dt[, point := as.numeric(point)]
+    }
+    
+    log_message(sprintf("Successfully parsed %d odds records", nrow(odds_dt)), "DEBUG")
+    
+    return(odds_dt)
+    
+  }, error = function(e) {
+    log_message(sprintf("Error in parse_odds_efficient: %s", e$message), "ERROR")
+    log_message(sprintf("Error details: %s", toString(e)), "DEBUG")
+    return(data.table())
+  })
+}
+
+#' Get best odds per team/market
+#' @param h2h_odds data.table with all odds
+#' @return data.table with best odds only
+get_best_odds <- function(h2h_odds) {
+  if (nrow(h2h_odds) == 0) return(h2h_odds)
+  
+  # Calculate price statistics by team/market
+  h2h_odds[, `:=`(
+    price_mean = mean(price, na.rm = TRUE),
+    price_sd = sd(price, na.rm = TRUE),
+    price_max = max(price, na.rm = TRUE),
+    price_min = min(price, na.rm = TRUE),
+    n_books = .N
+  ), by = .(home_team, away_team, market, name, game_date, game_time)]
+  
+  # Get best price per team/market
+  best_odds <- h2h_odds[, .SD[which.max(price)], 
+                       by = .(home_team, away_team, market, name, game_date, game_time)]
+  
+  return(best_odds)
+}
+
+# MAIN COLLECTION FUNCTION -------------------------------------------------
+
+#' Collect betting odds for date range
+#' @param dates Vector of dates to collect
+#' @param markets Character vector of markets (default: "h2h")
+#' @param regions Character regions code (default: "us")
+#' @return data.table with betting odds
+collect_espn_odds <- function(dates, sport, markets = "h2h", regions = "us") {
+  sport <- toupper(sport)
+  if (!sport %in% names(SPORT_MAPPINGS)) {
+    stop("Invalid sport: ", sport)
+  }
+  log_message(sprintf("Starting %s odds collection", sport), "INFO")
+  
+  # Validate inputs
+  dates <- parse_date_args(dates)
+  
+  # Check API key
+  if (is.null(espn_config$odds_api_key) || espn_config$odds_api_key == "") {
+    log_message("ODDS_API_KEY environment variable not set", "ERROR")
+    return(data.table())
+  }
+  
+  # Get date range
+  date_range <- c(min(dates), max(dates)+1)
+  
+  # Build query parameters
+  query_params <- list(
+    apiKey = espn_config$odds_api_key,
+    regions = regions,
+    markets = paste(markets, collapse = ","),
+    oddsFormat = "decimal",
+    dateFormat = "iso",
+    commenceTimeFrom = format(as.POSIXct(date_range[1], tz = "UTC"), 
+                              "%Y-%m-%dT00:00:00Z"),
+    commenceTimeTo = format(as.POSIXct(date_range[2] + 1, tz = "UTC") - 1, 
+                            "%Y-%m-%dT23:59:59Z")
+  )
+  
+  log_message(sprintf("Fetching odds for date range: %s to %s", 
+                      format(date_range[1], format = "%Y-%m-%d"),
+                      format(date_range[2], format = "%Y-%m-%d")), "INFO")
+  
+  # Make API request
+  endpoint <- sprintf("/v4/sports/%s/odds", SPORT_MAPPINGS[[sport]])
+  raw_data <- api_get(endpoint, api_type = "odds", query = query_params)
+  
+  if (is.null(raw_data)) {
+    log_message("Failed to retrieve odds data", "ERROR")
+    return(data.table())
+  }
+  
+  log_message(sprintf("Retrieved %d events from odds API", length(raw_data)), "INFO")
+  
+  # Parse the data
+  odds_tmp <- parse_odds_efficient(raw_data)
+  
+  if (nrow(odds_tmp) == 0) {
+    log_message("No odds data after parsing", "WARN")
+    return(data.table())
+  }
+  
+  # Filter to requested dates
+  odds_tmp <- odds_tmp[game_date %in% dates]
+  
+  if (nrow(odds_tmp) == 0) {
+    log_message("No odds found for specified dates", "WARN")
+    return(data.table())
+  }
+  
+  # Standardize team names
+  odds_tmp[, `:=`(
+    home_team = standardize_team_name(home_team),
+    away_team = standardize_team_name(away_team),
+    name = standardize_team_name(name)
+  )]
+  
+  odds_dt <- odds_tmp
+
+  # Get best odds if h2h market
+  if ("h2h" %in% markets) {
+    h2h_odds <- odds_tmp[market == "h2h"]
+    
+    if (nrow(h2h_odds) > 0) {
+      h2h_best <- get_best_odds(h2h_odds)
+      
+      # Replace h2h odds with best only
+      odds_dt <- rbind(
+        odds_tmp[market != "h2h"],
+        h2h_best,
+        fill = TRUE
+      )
+    }
+  }
+  
+  # Add metadata
+  odds_dt[, retrieved_time := format(Sys.time(), format = "%Y-%m-%dT%H:%M:%SZ", tz = "America/New_York")]
+  
+  # Select and order columns
+  final_cols <- c(
+    "game_date", "game_time", "home_team", "away_team", "name", "market",
+    "price", "point", "book", "price_mean", "price_min", "price_sd", "n_books",
+     "retrieved_time"
+  )
+  
+  # Keep only columns that exist
+  existing_cols <- intersect(final_cols, names(odds_dt))
+  odds_dt <- odds_dt[, ..existing_cols]
+  
+  # Sort
+  setorder(odds_dt, game_date, game_time, home_team, away_team, market, name, price, book, retrieved_time)
+  
+  log_message(sprintf("Retrieved %d odds entries for %d games across %d dates", 
+                      nrow(odds_dt),
+                      uniqueN(odds_dt[, paste(home_team, away_team)]),
+                      uniqueN(odds_dt$game_date)), "SUCCESS")
+  
+  # # Log market breakdown
+  # market_summary <- odds_dt[, .N, by = market]
+  # log_message(sprintf("Market breakdown: %s", 
+  #                     paste(sprintf("%s=%d", market_summary$market, market_summary$N), 
+  #                           collapse = ", ")), "INFO")
+  
+  # # Log bookmaker count
+  # log_message(sprintf("Found odds from %d different bookmakers", 
+  #                     uniqueN(odds_dt$book)), "INFO")
+  
+  return(odds_dt)
+}

--- a/R/espn_ev_retrieval/collectors/schedule.R
+++ b/R/espn_ev_retrieval/collectors/schedule.R
@@ -1,0 +1,103 @@
+# ESPN SCHEDULE COLLECTOR --------------------------------------------------
+# Purpose: collect schedule and win probabilities for various sports
+# Author: OpenAI ChatGPT
+# Last Updated: 2025-06-20
+
+suppressPackageStartupMessages({
+  library(data.table)
+  library(here)
+})
+
+source(here("R", "espn_ev_retrieval", "utils", "common.R"))
+source(here("R", "espn_ev_retrieval", "utils", "api_client.R"))
+
+# Basic sport mapping ------------------------------------------------------
+
+sport_map <- list(
+  NBA = list(sport = "basketball", league = "nba"),
+  NFL = list(sport = "football", league = "nfl"),
+  MLB = list(sport = "baseball", league = "mlb")
+)
+
+# Helper to build events endpoint
+build_events_endpoint <- function(date, sport_info) {
+  date_str <- format(as.Date(date), "%Y%m%d")
+  sprintf("/%s/leagues/%s/events?dates=%s&lang=en&region=us",
+          sport_info$sport, sport_info$league, date_str)
+}
+
+# Parse events JSON into data.table
+parse_espn_events <- function(events, sport) {
+  if (is.null(events) || length(events$items) == 0) return(data.table())
+
+  games <- list()
+  for (ev in events$items) {
+    ev_data <- api_get(ev$`$ref`, "espn")
+    if (is.null(ev_data)) next
+
+    comp <- ev_data$competitions[[1]]
+    if (is.null(comp$competitors) || length(comp$competitors) < 2) next
+
+    away <- comp$competitors[[1]]
+    home <- comp$competitors[[2]]
+    if (home$homeAway == "away") {
+      tmp <- home; home <- away; away <- tmp
+    }
+
+    game_dt <- data.table(
+      game_id = ev_data$id,
+      sport = sport,
+      game_date = as.Date(ev_data$date),
+      game_time = format(as.POSIXct(ev_data$date, tz = "UTC"), "%H:%M", tz = "America/New_York"),
+      home_team = standardize_team_name(home$team$displayName),
+      away_team = standardize_team_name(away$team$displayName),
+      home_win_prob = NA_real_,
+      away_win_prob = NA_real_
+    )
+
+    if (!is.null(ev_data$predictor$homeTeam$gameProjection)) {
+      game_dt$home_win_prob <- ev_data$predictor$homeTeam$gameProjection/100
+    }
+    if (!is.null(ev_data$predictor$awayTeam$gameProjection)) {
+      game_dt$away_win_prob <- ev_data$predictor$awayTeam$gameProjection/100
+    }
+
+    # sport specific extras (placeholder fields)
+    if (!is.null(home$probables)) {
+      game_dt$home_starter <- home$probables[[1]]$athlete$displayName
+    }
+    if (!is.null(away$probables)) {
+      game_dt$away_starter <- away$probables[[1]]$athlete$displayName
+    }
+
+    games[[length(games)+1]] <- game_dt
+  }
+
+  rbindlist(games, fill = TRUE)
+}
+
+# Main function ------------------------------------------------------------
+
+collect_espn_schedule <- function(dates, sport = "NBA") {
+  sport <- toupper(sport)
+  if (!sport %in% names(sport_map)) {
+    stop("Unsupported sport: ", sport)
+  }
+
+  dates <- parse_date_args(dates)
+  sport_info <- sport_map[[sport]]
+
+  out <- list()
+  for (d in dates) {
+    endpoint <- build_events_endpoint(d, sport_info)
+    events <- api_get(endpoint, "espn")
+    if (is.null(events)) next
+    out[[length(out)+1]] <- parse_espn_events(events, sport)
+  }
+
+  if (length(out) == 0) return(data.table())
+  res <- rbindlist(out, fill = TRUE)
+  setorder(res, game_date, game_time)
+  res
+}
+

--- a/R/espn_ev_retrieval/master.R
+++ b/R/espn_ev_retrieval/master.R
@@ -1,0 +1,75 @@
+# ESPN EV RETRIEVAL MASTER SCRIPT ----------------------------------------
+# Purpose: orchestrate collection of ESPN schedule, odds and compute EV
+# Author: OpenAI ChatGPT
+# Last Updated: 2025-06-20
+
+suppressPackageStartupMessages({
+  library(data.table)
+  library(here)
+})
+
+source(here("R","espn_ev_retrieval","utils","common.R"))
+source(here("R","espn_ev_retrieval","utils","api_client.R"))
+source(here("R","espn_ev_retrieval","collectors","schedule.R"))
+source(here("R","espn_ev_retrieval","collectors","odds.R"))
+
+retrieve_espn_expected_values <- function(dates = NULL, sport = "NBA", save_file = TRUE) {
+  init_logging("espn_ev")
+  check_delay_arg()
+  ensure_directories()
+
+  dates <- parse_date_args(dates)
+  log_message(sprintf("=== ESPN EV Retrieval for %s (%d dates) ===", sport, length(dates)), "INFO")
+
+  sched <- with_retry(collect_espn_schedule, dates = dates, sport = sport, context = "Schedule")
+  if (is.null(sched) || nrow(sched) == 0) {
+    log_message("No schedule data retrieved", "ERROR")
+    return(invisible(data.table()))
+  }
+
+  odds <- with_retry(collect_espn_odds, dates = dates, sport = sport, context = "Odds")
+  if (is.null(odds) || nrow(odds) == 0) {
+    log_message("No odds data retrieved", "ERROR")
+    return(invisible(data.table()))
+  }
+
+  win_dt <- rbind(
+    sched[!is.na(home_win_prob), .(game_id, game_date, game_time,
+                                   team = home_team, opponent = away_team,
+                                   win_probability = home_win_prob,
+                                   home_or_away = "home",
+                                   home_starter, away_starter)],
+    sched[!is.na(away_win_prob), .(game_id, game_date, game_time,
+                                   team = away_team, opponent = home_team,
+                                   win_probability = away_win_prob,
+                                   home_or_away = "away",
+                                   home_starter, away_starter)]
+  )
+
+  merged <- merge(win_dt, odds,
+                  by.x = c("game_date", "game_time", "team"),
+                  by.y = c("game_date", "game_time", "name"),
+                  all.x = TRUE)
+
+  merged[, `:=`(
+    expected_value = calculate_ev(price, win_probability),
+    kelly_criterion = calculate_kelly(price, win_probability),
+    retrieval_time = format(Sys.time(), "%Y-%m-%dT%H:%M:%SZ", tz = "America/New_York")
+  )]
+
+  if (save_file) {
+    out_file <- file.path(espn_config$data_dir, "expected_value",
+                          sprintf("%s_%s_ev.csv",
+                                  format(Sys.time(), "%Y%m%d_%H%M%S"), tolower(sport)))
+    fwrite(merged, out_file)
+    log_message(sprintf("Saved %d rows to %s", nrow(merged), out_file), "SUCCESS")
+  }
+
+  log_message("ESPN EV retrieval completed", "SUCCESS")
+  invisible(merged)
+}
+
+if (!interactive()) {
+  retrieve_espn_expected_values()
+}
+

--- a/R/espn_ev_retrieval/utils/api_client.R
+++ b/R/espn_ev_retrieval/utils/api_client.R
@@ -1,0 +1,267 @@
+# API CLIENT FOR ESPN DATA RETRIEVAL --------------------------------------
+# Purpose: Unified API client with caching and retry logic
+# Author: Professional implementation with httr
+# Last Updated: 2025-12-19
+
+suppressPackageStartupMessages({
+  library(httr)
+  library(jsonlite)
+  library(data.table)
+  library(R6)
+})
+
+# Source common utilities - use more robust path detection
+if (!exists("espn_config")) {
+  # Try relative path first
+  if (file.exists("utils/common.R")) {
+    source("utils/common.R")
+  } else if (file.exists("common.R")) {
+    source("common.R")
+  } else {
+    stop("Cannot find common.R - please ensure working directory is correct")
+  }
+}
+
+# API CLIENT CLASS ---------------------------------------------------------
+
+APIClient <- R6Class("APIClient",
+  private = list(
+    base_url = NULL,
+    # headers = NULL,
+    timeout = NULL,
+    cache = NULL,
+    cache_duration = 3600,  # 1 hour default
+    
+    # Build full URL
+    build_url = function(endpoint) {
+      # Remove leading slash if present
+      endpoint <- sub("^/", "", endpoint)
+      
+      # Handle query parameters
+      if (grepl("\\?", endpoint)) {
+        url <- paste0(private$base_url, "/", endpoint)
+      } else {
+        url <- paste0(private$base_url, "/", endpoint)
+      }
+      
+      return(url)
+    },
+    
+    # Get cache key
+    get_cache_key = function(url) {
+      return(digest::digest(url))
+    },
+    
+    # Check cache
+    check_cache = function(url) {
+      if (is.null(private$cache)) return(NULL)
+      
+      key <- private$get_cache_key(url)
+      if (key %in% names(private$cache)) {
+        cached <- private$cache[[key]]
+        
+        # Check if cache is still valid
+        if (difftime(Sys.time(), cached$timestamp, units = "secs") < private$cache_duration) {
+          log_message(sprintf("Cache hit for: %s", url), "DEBUG")
+          return(cached$data)
+        } else {
+          # Remove expired cache
+          private$cache[[key]] <- NULL
+        }
+      }
+      
+      return(NULL)
+    },
+    
+    # Set cache
+    set_cache = function(url, data) {
+      if (is.null(private$cache)) return()
+      
+      key <- private$get_cache_key(url)
+      private$cache[[key]] <- list(
+        data = data,
+        timestamp = Sys.time()
+      )
+    }
+  ),
+  
+  public = list(
+    # Initialize
+    initialize = function(base_url, # headers = list(), 
+                          timeout = espn_config$timeout,
+                          use_cache = TRUE, cache_duration = 3600) {
+      private$base_url <- sub("/$", "", base_url)  # Remove trailing slash
+      # private$headers <- headers
+      private$timeout <- timeout
+      private$cache_duration <- cache_duration
+      
+      if (use_cache) {
+        private$cache <- new.env(hash = TRUE)
+      }
+      
+      log_message(sprintf("API client initialized for: %s", private$base_url), "DEBUG")
+    },
+    
+    # Make GET request
+    get = function(endpoint, query = list(), use_cache = TRUE) {
+      url <- private$build_url(endpoint)
+      
+      # Check cache first
+      if (use_cache) {
+        cached_data <- private$check_cache(url)
+        if (!is.null(cached_data)) {
+          return(cached_data)
+        }
+      }
+      
+      # Make request with retry
+      response <- with_retry(
+        function() {
+          GET(
+            url,
+            query = query,
+            # add_headers(.headers = private$headers),
+            timeout(private$timeout)
+          )
+        },
+        context = sprintf("API request to %s", url)
+      )
+      
+      if (is.null(response)) {
+        return(NULL)
+      }
+      
+      # Check status
+      if (status_code(response) != 200) {
+        log_message(sprintf("API request failed with status %d: %s",
+                            status_code(response), url), "ERROR")
+        return(NULL)
+      }
+
+      # Quota information
+      hdr <- headers(response)
+      remaining <- hdr[["x-requests-remaining"]]
+      used      <- hdr[["x-requests-used"]]
+      last_cost <- hdr[["x-requests-last"]]
+      if (!is.null(remaining) || !is.null(used) || !is.null(last_cost)) {
+        log_message(
+          sprintf(
+            "Quota remaining: %s | Used: %s | Last cost: %s",
+            rlang::`%||%`(remaining, "NA"),
+            rlang::`%||%`(used, "NA"),
+            rlang::`%||%`(last_cost, "NA")
+          ),
+          "INFO"
+        )
+      }
+      
+      # Parse response
+      content_text <- content(response, "text", encoding = "UTF-8")
+      
+      data <- tryCatch({
+        fromJSON(content_text, simplifyDataFrame = TRUE)
+      }, error = function(e) {
+        log_message(sprintf("Failed to parse JSON response: %s", e$message), "ERROR")
+        NULL
+      })
+
+      if (!is.null(data)) {
+        attr(data, "response_headers") <- hdr
+      }
+      
+      # Cache successful response
+      if (!is.null(data) && use_cache) {
+        private$set_cache(url, data)
+      }
+      
+      return(data)
+    },
+    
+    # Clear cache
+    clear_cache = function() {
+      if (!is.null(private$cache)) {
+        rm(list = ls(private$cache), envir = private$cache)
+        log_message("API cache cleared", "DEBUG")
+      }
+    },
+    
+    # Get cache statistics
+    get_cache_stats = function() {
+      if (is.null(private$cache)) {
+        return(list(enabled = FALSE))
+      }
+      
+      cache_keys <- ls(private$cache)
+      return(list(
+        enabled = TRUE,
+        entries = length(cache_keys),
+        duration_seconds = private$cache_duration
+      ))
+    }
+  )
+)
+
+# ESPN API CLIENT -----------------------------------------------------------
+
+#' Create ESPN API client instance
+#' @param use_cache Whether to enable caching
+#' @return APIClient instance
+create_espn_api_client <- function(use_cache = TRUE) {
+  APIClient$new(
+    base_url = espn_config$espn_api_base,
+    # headers = list(Accept = "application/json"),
+    use_cache = use_cache,
+    cache_duration = 3600  # 1 hour for ESPN data
+  )
+}
+
+# ODDS API CLIENT ----------------------------------------------------------
+
+#' Create Odds API client instance
+#' @param use_cache Whether to enable caching
+#' @return APIClient instance
+create_odds_api_client <- function(use_cache = TRUE) {
+  if (is.null(espn_config$odds_api_key) || espn_config$odds_api_key == "") {
+    log_message("ODDS_API_KEY environment variable not set", "ERROR")
+    return(NULL)
+  }
+  
+  APIClient$new(
+    base_url = espn_config$odds_api_base,
+    # headers = list("Accept" = "application/json"),
+    use_cache = use_cache,
+    cache_duration = 600  # 10 minutes for odds (changes frequently)
+  )
+}
+
+# CONVENIENCE FUNCTIONS ----------------------------------------------------
+
+#' Make API request with automatic client selection
+#' @param endpoint API endpoint
+#' @param api_type Type of API ("espn" or "odds")
+#' @param query Query parameters
+#' @param use_cache Whether to use cache
+#' @return Parsed API response
+api_get <- function(endpoint, api_type = "espn", query = list(), use_cache = TRUE) {
+  # Get or create appropriate client
+  client_name <- paste0(api_type, "_api_client")
+  
+  if (!exists(client_name, envir = .GlobalEnv)) {
+    if (api_type == "espn") {
+      assign(client_name, create_espn_api_client(use_cache), envir = .GlobalEnv)
+    } else if (api_type == "odds") {
+      assign(client_name, create_odds_api_client(use_cache), envir = .GlobalEnv)
+    } else {
+      log_message(sprintf("Unknown API type: %s", api_type), "ERROR")
+      return(NULL)
+    }
+  }
+  
+  client <- get(client_name, envir = .GlobalEnv)
+  
+  if (is.null(client)) {
+    return(NULL)
+  }
+  
+  return(client$get(endpoint, query, use_cache))
+}

--- a/R/espn_ev_retrieval/utils/common.R
+++ b/R/espn_ev_retrieval/utils/common.R
@@ -1,0 +1,163 @@
+# SHARED UTILITIES FOR ESPN EV RETRIEVAL -----------------------------------
+# Purpose: Common helpers and configuration for ESPN scripts
+# Author: OpenAI ChatGPT
+# Last Updated: 2025-06-20
+
+suppressPackageStartupMessages({
+  library(data.table)
+  library(lubridate)
+  library(here)
+})
+
+# CONFIGURATION ------------------------------------------------------------
+
+espn_config <- list(
+  data_dir = here("data", "ESPN"),
+  log_file = NULL,
+
+  espn_api_base = "https://sports.core.api.espn.com/v2/sports",
+  odds_api_base = "https://api.the-odds-api.com",
+  odds_api_key = Sys.getenv("ODDS_API_KEY"),
+
+  retry_max = 3,
+  retry_delay = 2,
+  timeout = 30
+)
+
+# LOGGING FUNCTIONS --------------------------------------------------------
+
+init_logging <- function(script_name = "espn_ev") {
+  log_dir <- file.path(espn_config$data_dir, "logs")
+  dir.create(log_dir, showWarnings = FALSE, recursive = TRUE)
+
+  log_file <- file.path(log_dir,
+                        sprintf("%s_%s.log", script_name,
+                                format(Sys.time(), "%Y%m%d_%H%M%S")))
+
+  espn_config$log_file <<- log_file
+
+  cat(sprintf("ESPN %s Script Log\n", toupper(script_name)), file = log_file)
+  cat("Started:", format(Sys.time(), "%Y-%m-%d %H:%M:%S"), "\n",
+      file = log_file, append = TRUE)
+  cat(strrep("=", 60), "\n\n", file = log_file, append = TRUE)
+
+  return(log_file)
+}
+
+log_message <- function(msg, level = "INFO") {
+  timestamp <- format(Sys.time(), "%Y-%m-%d %H:%M:%S")
+  entry <- sprintf("[%s] %s: %s", timestamp, level, msg)
+
+  if (interactive() || level %in% c("ERROR", "WARN")) {
+    if (level == "ERROR") {
+      message(entry)
+    } else if (level == "SUCCESS") {
+      cat("\033[32m", entry, "\033[0m\n", sep = "")
+    } else if (level == "WARN") {
+      cat("\033[33m", entry, "\033[0m\n", sep = "")
+    } else {
+      cat(entry, "\n")
+    }
+  }
+
+  if (!is.null(espn_config$log_file)) {
+    cat(entry, "\n", file = espn_config$log_file, append = TRUE)
+  }
+}
+
+# DATE UTILITIES -----------------------------------------------------------
+
+parse_date_args <- function(dates = NULL) {
+  if (is.null(dates)) {
+    args <- commandArgs(trailingOnly = TRUE)
+    if (length(args) > 0 && args[1] != "delay") {
+      dates <- args[!args %in% "delay"]
+    } else {
+      dates <- c(Sys.Date(), Sys.Date() + 1)
+      log_message("No dates specified, using today and tomorrow")
+    }
+  }
+
+  if (is.character(dates)) {
+    dates <- tryCatch(as.Date(dates), error = function(e) {
+      log_message(sprintf("Invalid date format: %s", paste(dates, collapse = ", ")),
+                  "ERROR")
+      stop("Dates must be in YYYY-MM-DD format")
+    })
+  }
+
+  dates <- sort(unique(as.Date(dates)))
+
+  log_message(sprintf("Processing %d date(s): %s",
+                      length(dates),
+                      paste(format(dates, "%Y-%m-%d"), collapse = ", ")))
+
+  return(dates)
+}
+
+check_delay_arg <- function() {
+  args <- commandArgs(trailingOnly = TRUE)
+  if ("delay" %in% args) {
+    log_message("Delaying execution by 5 minutes...", "INFO")
+    Sys.sleep(300)
+    log_message("Resuming execution", "INFO")
+  }
+  invisible()
+}
+
+# TEAM NAME STANDARDIZATION ------------------------------------------------
+
+standardize_team_name <- function(names) {
+  if (is.null(names) || length(names) == 0) return(character(0))
+  out <- toupper(gsub("\\.", "", names))
+  out <- iconv(out, from = "UTF-8", to = "ASCII//TRANSLIT")
+  out <- gsub("[^A-Z0-9 ]", "", out)
+  trimws(out)
+}
+
+# CALCULATION FUNCTIONS ----------------------------------------------------
+
+calculate_ev <- function(line, win_prob) {
+  ifelse(is.na(line) | is.na(win_prob) | line <= 0 | win_prob <= 0 | win_prob > 1,
+         NA_real_, line * win_prob - 1)
+}
+
+calculate_kelly <- function(line, win_prob) {
+  ifelse(is.na(line) | is.na(win_prob) | line <= 1 | win_prob <= 0 | win_prob >= 1,
+         NA_real_, win_prob - ((1 - win_prob) / (line - 1)))
+}
+
+# RETRY WRAPPER ------------------------------------------------------------
+
+with_retry <- function(fn, ..., max_retries = espn_config$retry_max,
+                       delay = espn_config$retry_delay, context = "operation") {
+  for (attempt in 1:max_retries) {
+    res <- tryCatch(fn(...), error = function(e) {
+      if (attempt < max_retries) {
+        log_message(sprintf("%s failed (attempt %d/%d): %s. Retrying...",
+                            context, attempt, max_retries, e$message), "WARN")
+        Sys.sleep(delay * attempt)
+        NULL
+      } else {
+        log_message(sprintf("%s failed after %d attempts: %s",
+                            context, max_retries, e$message), "ERROR")
+        NULL
+      }
+    })
+    if (!is.null(res)) return(res)
+  }
+  NULL
+}
+
+# DIRECTORY MANAGEMENT -----------------------------------------------------
+
+ensure_directories <- function(subdirs = c("expected_value", "scores", "logs")) {
+  for (s in subdirs) {
+    p <- file.path(espn_config$data_dir, s)
+    if (!dir.exists(p)) {
+      dir.create(p, showWarnings = FALSE, recursive = TRUE)
+      log_message(sprintf("Created directory: %s", p), "DEBUG")
+    }
+  }
+}
+

--- a/tests/testthat/test-espn-common-utils.R
+++ b/tests/testthat/test-espn-common-utils.R
@@ -1,0 +1,15 @@
+library(here)
+library(withr)
+withr::local_dir(here::here())
+library(testthat)
+source(here("R","espn_ev_retrieval","utils","common.R"))
+
+test_that('espn standardize_team_name works', {
+  expect_equal(standardize_team_name(c('New York Knicks.', 'L.A. Lakers')), c('NEW YORK KNICKS','LA LAKERS'))
+})
+
+test_that('espn ev helpers work', {
+  expect_equal(calculate_ev(2,0.5), 0)
+  expect_true(is.na(calculate_ev(-1,0.5)))
+  expect_equal(round(calculate_kelly(2,0.5),3),0)
+})

--- a/tests/testthat/test-espn-schedule.R
+++ b/tests/testthat/test-espn-schedule.R
@@ -1,0 +1,25 @@
+library(here)
+library(withr)
+withr::local_dir(here::here())
+library(testthat)
+library(jsonlite)
+source(here("R","espn_ev_retrieval","collectors","schedule.R"))
+
+# load sample data
+events <- fromJSON("tests/testthat/testdata/espn_events.json", simplifyDataFrame = TRUE)
+event_data <- fromJSON("tests/testthat/testdata/espn_event.json", simplifyDataFrame = TRUE)
+
+mock_api <- function(endpoint, api_type="espn", query=list(), use_cache=TRUE) {
+  event_data
+}
+
+with_mock(api_get = mock_api, {
+  res <- parse_espn_events(events, "NBA")
+  test_that('parse_espn_events extracts teams and probabilities', {
+    expect_equal(nrow(res), 1)
+    expect_equal(res$home_team, 'NEW YORK KNICKS')
+    expect_equal(res$away_team, 'BOSTON CELTICS')
+    expect_equal(res$home_win_prob, 0.60)
+    expect_equal(res$away_win_prob, 0.40)
+  })
+})

--- a/tests/testthat/testdata/espn_event.json
+++ b/tests/testthat/testdata/espn_event.json
@@ -1,0 +1,16 @@
+{
+  "id": "game1",
+  "date": "2025-01-01T01:00:00Z",
+  "competitions": [
+    {
+      "competitors": [
+        {"team": {"displayName": "Boston Celtics"}, "homeAway": "away"},
+        {"team": {"displayName": "New York Knicks"}, "homeAway": "home"}
+      ]
+    }
+  ],
+  "predictor": {
+    "homeTeam": {"gameProjection": 60},
+    "awayTeam": {"gameProjection": 40}
+  }
+}

--- a/tests/testthat/testdata/espn_events.json
+++ b/tests/testthat/testdata/espn_events.json
@@ -1,0 +1,5 @@
+{
+  "items": [
+    {"$ref": "espn_event.json"}
+  ]
+}


### PR DESCRIPTION
## Summary
- add new `espn_ev_retrieval` module mirroring NHL workflow
- implement ESPN schedule and odds collectors
- provide common utilities for logging, team name cleaning and EV math
- orchestrate ESPN expected value generation via `master.R`
- include unit tests and sample ESPN data

## Testing
- `R` tests *(failed: command not found)*

------
https://chatgpt.com/codex/tasks/task_b_6855bfe10c3883319e51952e9d4ed08a