### PR TITLE
Fix ESPN schedule competitor parsing

### DIFF
--- a/R/espn_ev_retrieval/collectors/schedule.R
+++ b/R/espn_ev_retrieval/collectors/schedule.R
@@ -177,16 +177,21 @@ parse_espn_events <- function(events_data, sport) {
     # data.frame or list of data.frames.  Convert to a list of plain lists
     # representing each team in the competition.
     competitors <- comp$competitors
+
     if (is.data.frame(competitors)) {
       competitors <- df_to_row_list(competitors)
     } else if (is.list(competitors)) {
-      competitors <- lapply(competitors, function(x) {
-        if (is.data.frame(x)) {
-          if (nrow(x) > 0) as.list(x[1, , drop = TRUE]) else list()
-        } else {
-          x
-        }
-      })
+      if (length(competitors) == 1 && is.data.frame(competitors[[1]])) {
+        competitors <- df_to_row_list(competitors[[1]])
+      } else {
+        competitors <- lapply(competitors, function(x) {
+          if (is.data.frame(x)) {
+            df_to_row_list(x)[[1]]
+          } else {
+            x
+          }
+        })
+      }
     } else {
       competitors <- list()
     }

--- a/tests/testthat/test-espn-schedule.R
+++ b/tests/testthat/test-espn-schedule.R
@@ -23,3 +23,20 @@ with_mock(api_get = mock_api, {
     expect_equal(res$away_win_prob, 0.40)
   })
 })
+
+# competitors wrapped in an extra list
+wrapped_event <- event_data
+wrapped_event$competitions[[1]]$competitors <- list(as.data.frame(wrapped_event$competitions[[1]]$competitors))
+
+mock_api2 <- function(endpoint, api_type="espn", query=list(), use_cache=TRUE) {
+  wrapped_event
+}
+
+with_mock(api_get = mock_api2, {
+  res <- parse_espn_events(events, "NBA")
+  test_that('parse_espn_events handles wrapped competitors', {
+    expect_equal(nrow(res), 1)
+    expect_equal(res$home_team, 'NEW YORK KNICKS')
+    expect_equal(res$away_team, 'BOSTON CELTICS')
+  })
+})


### PR DESCRIPTION
## Summary
- fix competitor parsing in ESPN schedule collector
- ensure competitor arrays wrapped in lists are handled correctly
- add regression test for wrapped competitor case

## Testing
- `R -q -e "testthat::test_dir('tests/testthat')"` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_b_6856b825269c833184e1cab677b78119